### PR TITLE
Update mbtiles.py

### DIFF
--- a/mbtiles.py
+++ b/mbtiles.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser
 from shutil import copyfile
 import os
 import sys
+import platform
 
 parser = ArgumentParser()
 parser.add_argument("--input", dest="input", required=True,
@@ -37,6 +38,11 @@ parser.add_argument("--output", dest="output", default="output",
 
 args = parser.parse_args()
 
+if platform.system() == "Windows":
+    try:
+        os.mkdir("app")
+    except:
+        pass
 app_path = os.path.join(os.getcwd(), "app")
 input_path = os.path.join(os.getcwd(), "input")
 output_path = os.path.join(os.getcwd(), "output")


### PR DESCRIPTION
@zhm I noticed this issue when running `fulcrum-tiler` on Windows 10. I think Docker automatically creates the mount folders if they don't exist on Mac, but Windows doesn't ...or something like that. Not sure if my additions are the best way to handle this, but they seem to work to avoid this issue.

```
PS C:\Users\vagrant\fulcrum-tiler> python mbtiles.py --input ..\Downloads\Supervisorial_Districts__Current.kml --max-zoom 14 --text-name Name
docker pull fulcrumapp/tiler && docker run --name fulcrum-tiler --memory 4gb --rm -v C:\Users\vagrant\fulcrum-tiler\input:/input -v C:\Users\vagrant\fulcrum-tiler\output:/output -v C:\Users\vagrant\fulcrum-tiler\app:/root/Documents/MapBox -it --entrypoint="" fulcrumapp/tiler:latest bash -c "cd /tileoven/scripts && ruby mbtiles.rb export --file Supervisorial_Districts__Current.kml --input '..\Downloads\Supervisorial_Districts__Current.kml' --max-zoom '14' --text-name 'Name'"
Using default tag: latest
latest: Pulling from fulcrumapp/tiler
Digest: sha256:dc09b68be9cc8846cfb9c2ffc1704a4f227da2c5534fe166013965371f446b24
Status: Image is up to date for fulcrumapp/tiler:latest
docker: Error response from daemon: Mount denied:
The source path "C:/Users/vagrant/fulcrum-tiler/app"
doesn't exist and is not known to Docker.
See 'docker run --help'.
PS C:\Users\vagrant\fulcrum-tiler>
```